### PR TITLE
Add `/bid/cancel` API route

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
       "type": "node",
       "request": "launch",
       "name": "Launch Program",
-      "program": "${workspaceFolder}\\build\\index.js"
+      "program": "${workspaceFolder}\\build\\src\\index.js"
     },
     {
       "type": "node",

--- a/src/api.ts
+++ b/src/api.ts
@@ -223,9 +223,6 @@ router.post(
         req.body.cancelMessageSignature
       );
 
-      console.log(signer);
-      console.log(bidData.account);
-
       if (signer !== bidData.account) {
         return res.status(400).send("Incorrect signer address recovered");
       }

--- a/src/database/adapters/mongo.ts
+++ b/src/database/adapters/mongo.ts
@@ -42,11 +42,29 @@ export const create = (db: string, collection: string): BidDatabaseService => {
     return result;
   };
 
+  const getBidBySignedMessage = async (
+    signedMessage: string
+  ): Promise<Bid | null> => {
+    const result: Bid | null = await mongo.findOne(database, collection, {
+      signedMessage: `${signedMessage}`,
+    });
+    return result;
+  };
+
+  const cancelBid = async (signedMessage: string): Promise<boolean> => {
+    const result: boolean = await mongo.deleteOne(database, usedCollection, {
+      signedMessage: `${signedMessage}`,
+    });
+    return result;
+  };
+
   const databaseService = {
     insertBid,
     insertBids,
     getBidsByNftId,
     getBidsByAccount,
+    getBidBySignedMessage,
+    cancelBid,
   };
 
   return databaseService;

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -6,4 +6,6 @@ export interface BidDatabaseService {
   insertBids: (data: Bid[]) => Promise<boolean>;
   getBidsByNftId: (nftId: string) => Promise<Bid[]>;
   getBidsByAccount: (account: string) => Promise<Bid[]>;
+  getBidBySignedMessage: (signedMessage: string) => Promise<Bid | null>;
+  cancelBid: (signedMessage: string) => Promise<boolean>;
 }

--- a/src/migration/index.ts
+++ b/src/migration/index.ts
@@ -39,7 +39,7 @@ const getAllFileKeys = async (
   buckets: listBucketsOutput[],
   folder: string
 ): Promise<listFilesOutput[]> => {
-  let allFiles: listFilesOutput[] = [];
+  const allFiles: listFilesOutput[] = [];
 
   for (const index in buckets) {
     const request: listFilesInput = {
@@ -101,7 +101,7 @@ async function migrateExistingBids(auth: FleekAuth) {
         ...bid,
       };
       bids.push(newBid);
-    };
+    }
   }
 
   const result = await database.insertBids(bids);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -5,6 +5,7 @@ import {
   BidsListDto,
   BidsAccountsDto,
   BidsDto,
+  BidCancelDto,
 } from "./types";
 
 const ajv = new Ajv({ coerceTypes: true });
@@ -93,3 +94,14 @@ const bidsGetSchema: JSONSchemaType<BidsDto> = {
 };
 
 export const validateBidsGetSchema = ajv.compile(bidsGetSchema);
+
+const bidCancelSchema: JSONSchemaType<BidCancelDto> = {
+  type: "object",
+  properties: {
+    cancelMessageSignature: { type: "string" },
+    bidMessageSignature: { type: "string" },
+  },
+  required: ["cancelMessageSignature", "bidMessageSignature"],
+};
+
+export const validateBidCancelSchema = ajv.compile(bidCancelSchema);


### PR DESCRIPTION
The `/bid/cancel` API route receives a signed cancel message hash as well as a bid message hash. We use the bid message hash to find the existing bid in our DB so that we can reconstruct the unsigned version of a cancel message with that bids data. After this, we call to `ethers.utils.verifyMessage()` with the reconstructed unsigned cancel message and the provided signed cancel message to return the account that signed it. If the account that signed is the same as the account in the bid data, we move forward with cancelling that bid and it gets deleted from the database.