### PR TITLE
Add endpoint for ping that we can later call from a script in a heroku app

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -263,5 +263,22 @@ router.post(
     }
   }
 );
+router.get(
+  "/ping",
+  limiter,
+  async (req: express.Request, res: express.Response) => {
+    const infuraUrl = process.env["INFURA_URL"];
+    if (!infuraUrl) {
+      throw Error("No Infura URL could be found")
+    }
+    const sampleProvider = new ethers.providers.JsonRpcProvider(infuraUrl);
+    const blockNumber = await sampleProvider.getBlockNumber();
+
+    if (!blockNumber) {
+      throw Error("Looks like something went wrong with the Infura connection.");
+    }
+
+    return res.status(200);
+  })
 
 export = router;


### PR DESCRIPTION
We can enable a job to periodically hit this endpoint and confirm that we always have an Infura URL and can use it. From here we can set custom alerts on that heroku app to notify the team if it's failing