### PR TITLE
Improve the way the connection to Event Hub is managed

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -317,10 +317,9 @@ router.post(
       };
 
       await queue.sendMessage(message);
-      // await queue.close(); 
 
       return res.status(200).send();
-    } catch (e: any) { // have to type message?
+    } catch (e) {
       console.error(e.message, e.stack);
       next(
         new Error(

--- a/src/api.ts
+++ b/src/api.ts
@@ -231,7 +231,7 @@ router.post(
       };
 
       // Add new bid to our event queue
-      //await queue.sendMessage(message);
+      await queue.sendMessage(message);
 
       return res.status(200).send("OK");
     } catch (error) {
@@ -304,22 +304,23 @@ router.post(
       // Once confirmed, move to archive collection
       await database.cancelBid(bidData, archiveCollection);
 
-      // const message: TypedMessage<BidCancelledV1Data> = {
-      //   event: MessageType.BidCancelled,
-      //   version: "1.0",
-      //   timestamp: new Date().getTime(),
-      //   logIndex: undefined,
-      //   blockNumber: undefined,
-      //   data: {
-      //     account: signer,
-      //     uniqueBidId: bidData.uniqueBidId,
-      //   },
-      // };
+      const message: TypedMessage<BidCancelledV1Data> = {
+        event: MessageType.BidCancelled,
+        version: "1.0",
+        timestamp: new Date().getTime(),
+        logIndex: undefined,
+        blockNumber: undefined,
+        data: {
+          account: signer,
+          uniqueBidId: bidData.uniqueBidId,
+        },
+      };
 
-      // await queue.sendMessage(message);
+      await queue.sendMessage(message);
+      // await queue.close(); 
 
       return res.status(200).send();
-    } catch (e) {
+    } catch (e: any) { // have to type message?
       console.error(e.message, e.stack);
       next(
         new Error(

--- a/src/messagequeue/adapters/eventhub.ts
+++ b/src/messagequeue/adapters/eventhub.ts
@@ -1,13 +1,16 @@
 import { EventData, EventHubProducerClient } from "@azure/event-hubs";
 import { Message } from "@zero-tech/zns-message-schemas";
+import { MessageQueueService } from "..";
 
-export const create = (connectionString: string, name: string) => {
-  const producer: EventHubProducerClient = new EventHubProducerClient(
-    connectionString,
-    name
-  );
-
+export const create = (
+  connectionString: string,
+  name: string
+): MessageQueueService => {
   const sendMessage = async (message: Message) => {
+    const producer: EventHubProducerClient = new EventHubProducerClient(
+      connectionString,
+      name
+    );
     const batch = await producer.createBatch();
 
     const event: EventData = {
@@ -20,7 +23,7 @@ export const create = (connectionString: string, name: string) => {
     await producer.close();
   };
 
-  const messageQueueService = {
+  const messageQueueService: MessageQueueService = {
     sendMessage,
   };
   return messageQueueService;


### PR DESCRIPTION
Similar to the way we manage the database connection, each request should open a new client, perform an action, and close the client. Leaving clients open could negatively impact the performance of the app, but we also can't rely on just one specific endpoint being responsible for closing either expecting some specific user flow. So every request that uses the Event Hub service is responsible for opening and closing that connection.