### PR TITLE
Update API to include bid version

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,0 +1,19 @@
+name: Notify CPT
+on:
+  pull_request:
+    types: [opened, reopened]
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: send telegram message on push
+        uses: appleboy/telegram-action@master
+        with:
+          to: ${{ secrets.TELEGRAM_TO }}
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          message: |
+            ${{ github.actor }} opened a PR for review:
+
+            ${{ github.event.pull_request.title }}  
+            ${{ github.event.pull_request._links.html.href }}      

--- a/src/api.ts
+++ b/src/api.ts
@@ -183,6 +183,7 @@ router.post(
         ...bidParams,
         signedMessage: dto.signedMessage,
         date: dateNow.getTime(),
+        version: "2.0"
       };
 
       // Add new bid document to database

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,7 @@ export interface BidsDto {
 export interface Bid extends BidParams {
   date: number;
   signedMessage: string;
+  version?: string
 }
 
 export interface Auction {


### PR DESCRIPTION
Addition of a bid version will allow the SDK to be backwards compatible. New bids that have a bid version will be routed to the updated zAuction contract, but older bids without this version number will be sent to the old contract. This way we don't have to expire any bids which may cause issues.

Also update ABI and typechain files.